### PR TITLE
Split stations into new JSON. Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,6 @@ The goal of this webpage is to provide a utility for generating Stars Without Nu
 
 This is still a work in progress. Some ships don't exactly fulfill their roles, and the generator can be forced to build invalid ship combinations (like putting a spike drive level 6 on a strike fighter). I hope to change these things in the future, and add a bunch more functionality!
 
-Next on my to-do list is improving the auto-generated names.
+>Space station generation has been temporarily disabled as I do some bugfixing
 
 *Built with Create React App and Redux.*

--- a/src/app/resources/hulls.json
+++ b/src/app/resources/hulls.json
@@ -148,35 +148,5 @@
     "class": "Capital",
     "CP": "6",
     "skill": "3"
-  },
-  "SmallStation": {
-    "name": "Small Station",
-    "cost": "5m",
-    "speed": "N/A",
-    "armor": "5",
-    "HP": "120",
-    "crew": "20/200",
-    "AC": "11",
-    "power": "50",
-    "mass": "40",
-    "hardpoints": "10",
-    "class": "Cruiser",
-    "CP": "5",
-    "skill": "2"
-  },
-  "LargeStation": {
-    "name": "Large Station",
-    "cost": "40m",
-    "speed": "N/A",
-    "armor": "20",
-    "HP": "120",
-    "crew": "100/1000",
-    "AC": "17",
-    "power": "125",
-    "mass": "75",
-    "hardpoints": "30",
-    "class": "Capital",
-    "CP": "6",
-    "skill": "3"
   }
 }

--- a/src/app/resources/stations.json
+++ b/src/app/resources/stations.json
@@ -1,0 +1,32 @@
+{
+  "SmallStation": {
+    "name": "Small Station",
+    "cost": "5m",
+    "speed": "N/A",
+    "armor": "5",
+    "HP": "120",
+    "crew": "20/200",
+    "AC": "11",
+    "power": "50",
+    "mass": "40",
+    "hardpoints": "10",
+    "class": "Cruiser",
+    "CP": "5",
+    "skill": "2"
+  },
+  "LargeStation": {
+    "name": "Large Station",
+    "cost": "40m",
+    "speed": "N/A",
+    "armor": "20",
+    "HP": "120",
+    "crew": "100/1000",
+    "AC": "17",
+    "power": "125",
+    "mass": "75",
+    "hardpoints": "30",
+    "class": "Capital",
+    "CP": "6",
+    "skill": "3"
+  }
+}


### PR DESCRIPTION
Small and Large stations have been split into a new .JSON file to prevent them from showing up on hull lists. This is done to prevent their generation as they currently calculate fittings, but they are not passed to the ship slice for some reason. They can be put back into hulls.json when that is fixed.